### PR TITLE
Fix nested id conflict

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "mailbox",
-  "version": "0.9.5",
+  "version": "0.9.6",
   "description": "Mailbox is for converting a XState Machine to an Actor that can deal with concurrency requests",
   "type": "module",
   "exports": {

--- a/package.json
+++ b/package.json
@@ -40,7 +40,7 @@
     "lint": "npm-run-all lint:es lint:ts",
     "lint:ts": "tsc --isolatedModules --noEmit",
     "test": "npm-run-all lint test:unit",
-    "test:unit": "cross-env NODE_OPTIONS=\"--no-warnings --loader=ts-node/esm\" tap \"src/**/*.spec.ts\" \"tests/*.spec.ts\"",
+    "test:unit": "cross-env NODE_OPTIONS=\"--no-warnings --loader=ts-node/esm\" tap \"src/**/*.spec.ts\" \"tests/**/*.spec.ts\"",
     "test:pack": "bash -x scripts/npm-pack-testing.sh",
     "lint:es": "eslint --ignore-pattern fixtures/ \"src/**/*.ts\" \"tests/**/*.ts\""
   },

--- a/src/actions/proxy.ts
+++ b/src/actions/proxy.ts
@@ -36,12 +36,12 @@ import { send } from './send.js'
  * And send all other events to the target address,
  * by setting the `origin` to the current machine address.
  *
- * @param id Self Machine ID
+ * @param actorId Self Machine ID
  * @param toAddress {string | Address | Mailbox} the target address
  *  - string: the sessionId of the interpreter, or invoke.id of the child machine
  */
-export const proxy = (id: string) => (toAddress: string | impls.Address | impls.Mailbox) => {
-  const moduleName = `Mailbox<${id}>`
+export const proxy = (actorId: string) => (toAddress: string | impls.Address | impls.Mailbox) => {
+  const moduleName = `Mailbox<${actorId}>`
 
   return actions.choose([
     {

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -1,2 +1,0 @@
-export const MAILBOX_NAME             = 'Mailbox'
-export const MAILBOX_ACTOR_MACHINE_ID = 'mailbox-actor-machind-id'

--- a/src/context/child/snapshot.spec.ts
+++ b/src/context/child/snapshot.spec.ts
@@ -1,10 +1,61 @@
 #!/usr/bin/env -S node --no-warnings --loader ts-node/esm
 /* eslint-disable sort-keys */
 
-import { test }    from 'tstest'
+import { test }                     from 'tstest'
+import { createMachine, actions, interpret, AnyEventObject }   from 'xstate'
 
 import { snapshot }   from './snapshot.js'
 
 test('snapshot() smoke testing', async t => {
-  t.ok(snapshot, 'tbw')
+  const CHILD_ID = 'child-id'
+  const child = createMachine({
+    id: CHILD_ID,
+    context: {
+      child: true,
+    },
+    initial: 'idle',
+    states: {
+      idle: {},
+    },
+  })
+
+  const PARENT_ID = 'parent-id'
+  const parent = createMachine<any, any>({
+    id: PARENT_ID,
+    invoke: {
+      id: CHILD_ID,
+      src: child,
+    },
+    initial: 'idle',
+    states: {
+      idle: {
+        on: {
+          TEST: {
+            actions: actions.choose<any, any>([
+              {
+                cond: (_, __, meta) => !!snapshot(CHILD_ID)(meta.state),
+                actions: actions.send('SNAPSHOT_GOT'),
+              },
+            ]),
+          },
+        },
+      },
+    },
+  })
+
+  const eventList: AnyEventObject[] = []
+  const interpreter = interpret(parent)
+    .onEvent(e => {
+      eventList.push(e)
+    })
+    .start()
+
+  eventList.length = 0
+  interpreter.send('TEST')
+  await new Promise(setImmediate)
+
+  t.same(eventList, [
+    { type: 'TEST' },
+    { type: 'SNAPSHOT_GOT' },
+  ], 'should be able to get snapshot of CHILD_ID in actions.choose of PARENT_ID')
 })

--- a/src/context/child/snapshot.ts
+++ b/src/context/child/snapshot.ts
@@ -24,8 +24,8 @@ import type { Context }   from '../context'
 /**
  * Get snapshot by child id (with currying) from state
  */
-export const snapshot: (childId: string) => (state: State<Context, EventObject, any, any>) => State<any, EventObject, any, any> | undefined
+export const snapshot: (childId: string) => (state?: State<Context, EventObject, any, any>) => State<any, EventObject, any, any> | undefined
   = childId => state => {
-    const child = state.children[childId]
+    const child = state?.children[childId]
     return child?.getSnapshot()
   }

--- a/src/context/cond/is-child-busy-acceptable.ts
+++ b/src/context/cond/is-child-busy-acceptable.ts
@@ -21,8 +21,6 @@ import type { AnyEventObject, GuardMeta }   from 'xstate'
 
 import * as duck    from '../../duck/mod.js'
 
-import { MAILBOX_ACTOR_MACHINE_ID }  from '../../constants.js'
-
 import * as child         from '../child/mod.js'
 import * as request       from '../request/mod.js'
 
@@ -55,7 +53,7 @@ const canChildAccept = (event : AnyEventObject, meta: GuardMeta<Context, AnyEven
  *  2. the new message origin is the same as the curent message which is in processing
  *  3. the new message type can be accepted by the current actor state
  */
-export const isChildBusyAcceptable = (childId = MAILBOX_ACTOR_MACHINE_ID) =>
+export const isChildBusyAcceptable = (childId: string) =>
   (
     ctx   : Context,
     event : AnyEventObject,

--- a/src/context/cond/is-event-from.spec.ts
+++ b/src/context/cond/is-event-from.spec.ts
@@ -4,8 +4,6 @@
 import { test }                               from 'tstest'
 import type { ActorRef, GuardMeta, SCXML }    from 'xstate'
 
-import { MAILBOX_ACTOR_MACHINE_ID }   from '../../constants.js'
-
 import { isEventFrom } from './is-event-from.js'
 
 test('isEventFrom()', async t => {
@@ -15,8 +13,10 @@ test('isEventFrom()', async t => {
     origin: SESSION_ID,
   } as any as SCXML.Event<any>
 
+  const WRAPPED_ACTOR_ID = 'wrapped-id'
+
   const CHILDREN: Record<string, ActorRef<any, any>> = {
-    [MAILBOX_ACTOR_MACHINE_ID]: {
+    [WRAPPED_ACTOR_ID]: {
       sessionId: SESSION_ID,
     } as any as ActorRef<any, any>,
   }
@@ -26,13 +26,13 @@ test('isEventFrom()', async t => {
     state: { children: CHILDREN },
   } as GuardMeta<any, any>
 
-  t.ok(isEventFrom(MAILBOX_ACTOR_MACHINE_ID)({}, _EVENT, META), 'should return true if the event origin is the child session id')
+  t.ok(isEventFrom(WRAPPED_ACTOR_ID)({}, _EVENT, META), 'should return true if the event origin is the child session id')
 
   META._event.origin = undefined
-  t.notOk(isEventFrom(MAILBOX_ACTOR_MACHINE_ID)({}, _EVENT, META), 'should return false if the event origin is undefined')
+  t.notOk(isEventFrom(WRAPPED_ACTOR_ID)({}, _EVENT, META), 'should return false if the event origin is undefined')
 
   t.notOk(
-    isEventFrom(MAILBOX_ACTOR_MACHINE_ID)({}, _EVENT, { _event: {} } as any),
+    isEventFrom(WRAPPED_ACTOR_ID)({}, _EVENT, { _event: {} } as any),
     'should return false for undefined origin',
   )
 })

--- a/src/impls/get-actor-machine.spec.ts
+++ b/src/impls/get-actor-machine.spec.ts
@@ -22,11 +22,11 @@ import Baby   from '../../tests/machine-behaviors/baby-machine.js'
 
 import { wrap }   from '../wrap.js'
 
-import { getTargetMachine }   from './get-actor-machine.js'
+import { getActorMachine }   from './get-actor-machine.js'
 
-test('getTargetMachine()', async t => {
+test('getActorMachine()', async t => {
   const machine = Baby.machine.withContext(Baby.initialContext())
   const wrappedMachine = wrap(machine)
-  const targetMachine = getTargetMachine(wrappedMachine)
-  t.equal(targetMachine, machine, 'should return target machine')
+  const targetMachine = getActorMachine(wrappedMachine)
+  t.equal(targetMachine, machine, 'should return actor machine')
 })

--- a/src/impls/get-actor-machine.ts
+++ b/src/impls/get-actor-machine.ts
@@ -22,18 +22,22 @@
 
 import type { AnyStateMachine }    from 'xstate'
 
-import { MAILBOX_ACTOR_MACHINE_ID }    from '../constants.js'
-
-export const getTargetMachine = (wrappedMachine: AnyStateMachine) => {
-  const services = wrappedMachine.options.services
+/**
+ * The wrapped machine only have one child: the original actor machine.
+ *
+ * @param wrappedActorMachine
+ * @returns
+ */
+export const getActorMachine = (wrappedActorMachine: AnyStateMachine) => {
+  const services = wrappedActorMachine.options.services
   if (!services) {
     throw new Error('no services provided in the wrappedMachine!')
   }
 
-  const childMachine = services[MAILBOX_ACTOR_MACHINE_ID]
-  if (!childMachine) {
-    throw new Error('no child machine found in wrappedMachine!')
+  const originalActorMachine = Object.values(services)[0]
+  if (!originalActorMachine) {
+    throw new Error('no actor machine found in wrappedMachine!')
   }
 
-  return childMachine as AnyStateMachine
+  return originalActorMachine as AnyStateMachine
 }

--- a/src/impls/mailbox-implementation.ts
+++ b/src/impls/mailbox-implementation.ts
@@ -37,11 +37,10 @@ import * as duck            from '../duck/mod.js'
 import { isMailboxType }    from '../is/mod.js'
 import type { Context }     from '../context/mod.js'
 
-import { MAILBOX_ACTOR_MACHINE_ID }   from '../constants.js'
 import type { Mailbox, Options }      from '../interface.js'
 
 import type { Address }       from './address-interface.js'
-import { getTargetMachine }   from './get-actor-machine.js'
+import { getActorMachine }    from './get-actor-machine.js'
 import { AddressImpl }        from './address-implementation.js'
 
 /**
@@ -138,7 +137,7 @@ export class MailboxImpl<
       machine: wrappedMachine,
       interpreter: this._interpreter,
       actor: {
-        machine: getTargetMachine(wrappedMachine),
+        machine: getActorMachine(wrappedMachine),
       },
     }
   }
@@ -173,11 +172,18 @@ export class MailboxImpl<
     this._opened = true
 
     /**
+     * The wrapped machine has only one child machine, which is the original actor machine.
+     *
      * Huan(202203): FIXME:
      *  will ` ActorRef<any, any> as AnyInterpreter` be a problem?
+     *
+     * SO: Get first value from iterator
+     *  @link https://stackoverflow.com/questions/32539354/how-to-get-the-first-element-of-set-in-es6-ecmascript-2015#comment79971478_32539929
      */
     this.internal.actor.interpreter = this._interpreter.children
-      .get(MAILBOX_ACTOR_MACHINE_ID) as AnyInterpreter
+      .values()
+      .next()
+      .value as AnyInterpreter
   }
 
   /**

--- a/src/interface.ts
+++ b/src/interface.ts
@@ -25,7 +25,6 @@ import type { EventObject, InterpreterOptions }   from 'xstate'
 import type { Address }   from './impls/address-interface.js'
 
 export interface Options {
-  id?       : string
   capacity? : number
   logger?   : InterpreterOptions['logger'],
   devTools? : InterpreterOptions['devTools'],

--- a/src/mailbox-id.spec.ts
+++ b/src/mailbox-id.spec.ts
@@ -1,0 +1,25 @@
+#!/usr/bin/env -S node --no-warnings --loader ts-node/esm
+
+import { test }  from 'tstest'
+
+import { mailboxId, wrappedId } from './mailbox-id.js'
+
+test('mailboxId()', async t => {
+  const FIXTURE = [
+    [ 'Test', 'Test<Mailbox>' ],
+  ] as const
+
+  for (const [ actorMachineId, expected ] of FIXTURE) {
+    t.equal(mailboxId(actorMachineId), expected, `should return ${expected} for ${actorMachineId}`)
+  }
+})
+
+test('wrappedId()', async t => {
+  const FIXTURE = [
+    [ 'Test', 'Test<Mailbox><Wrapped>' ],
+  ] as const
+
+  for (const [ actorMachineId, expected ] of FIXTURE) {
+    t.equal(wrappedId(actorMachineId), expected, `should return ${expected} for ${actorMachineId}`)
+  }
+})

--- a/src/mailbox-id.ts
+++ b/src/mailbox-id.ts
@@ -1,0 +1,2 @@
+export const mailboxId = (actorMachineId: string) => `${actorMachineId}<Mailbox>`
+export const wrappedId = (actorMachineId: string) => `${mailboxId(actorMachineId)}<Wrapped>`

--- a/tests/machine-behaviors/baby-machine.spec.ts
+++ b/tests/machine-behaviors/baby-machine.spec.ts
@@ -152,7 +152,7 @@ test('babyMachine smoke testing with asleep under mock clock', async t => {
   t.same(
     babyEventList,
     [
-      { type: 'xstate.after(cryMs)#baby.baby/asleep' },
+      { type: 'xstate.after(cryMs)#Baby.baby/asleep' },
     ],
     'should cry in middle night (after 2nd 4 ms) for child',
   )
@@ -179,7 +179,7 @@ test('babyMachine smoke testing with asleep under mock clock', async t => {
     Mailbox.Type.ACTOR_REPLY,
   ], 'should pee after night and start paly in the morning, sent to parent')
   t.same(babyEventList.map(e => e.type), [
-    'xstate.after(ms)#baby.baby/asleep',
+    'xstate.after(ms)#Baby.baby/asleep',
   ], 'should received after(ms) event for child')
 
   proxyInterpreter.stop()

--- a/tests/machine-behaviors/baby-machine.ts
+++ b/tests/machine-behaviors/baby-machine.ts
@@ -40,7 +40,7 @@ const Event = {
 type Context = { ms?: number }
 
 const duckula = Mailbox.duckularize({
-  id: 'BabyActor',
+  id: 'Baby',
   events: Event,
   states: State,
   initialContext: {} as Context,
@@ -55,7 +55,7 @@ const machine = createMachine<
   ReturnType<typeof duckula.Event[keyof typeof duckula.Event]>,
   any
 >({
-  id: 'baby',
+  id: duckula.id,
   initial: duckula.State.awake,
   states: {
     [duckula.State.awake]: {

--- a/tests/machine-behaviors/coffee-maker-machine.ts
+++ b/tests/machine-behaviors/coffee-maker-machine.ts
@@ -24,7 +24,7 @@ interface Context {
 }
 
 const duckula = Mailbox.duckularize({
-  id: 'CoffeeMakerActor',
+  id: 'CoffeeMaker',
   events: Event,
   states: State,
   initialContext: {} as Context,
@@ -36,6 +36,7 @@ const machine = createMachine<
   ReturnType<typeof duckula.initialContext>,
   ReturnType<typeof Event[keyof typeof Event]>
 >({
+  id: duckula.id,
   initial: duckula.State.idle,
   states: {
     [duckula.State.idle]: {

--- a/tests/machine-behaviors/ding-dong-machine.ts
+++ b/tests/machine-behaviors/ding-dong-machine.ts
@@ -24,7 +24,7 @@ interface Context {
 }
 
 const duckula = Mailbox.duckularize({
-  id: 'DingDongActor',
+  id: 'DingDong',
   events,
   states: State,
   initialContext: { i: 0 } as Context,
@@ -33,10 +33,10 @@ const duckula = Mailbox.duckularize({
 const MAX_DELAY_MS = 10
 
 const machine = createMachine<
-  ReturnType<typeof duckula.initialContext>,
+  Context,
   ReturnType<typeof duckula.Event[keyof typeof duckula.Event]>
 >({
-  id: 'ding-dong',
+  id: duckula.id,
   initial: duckula.State.idle,
   context: {
     i: -1,

--- a/tests/machine-behaviors/nested-mailbox-machine.spec.ts
+++ b/tests/machine-behaviors/nested-mailbox-machine.spec.ts
@@ -1,0 +1,64 @@
+#!/usr/bin/env -S node --no-warnings --loader ts-node/esm
+/* eslint-disable @typescript-eslint/no-unnecessary-condition */
+/* eslint-disable sort-keys */
+import {
+  AnyEventObject,
+  interpret,
+}                                       from 'xstate'
+import { test }                         from 'tstest'
+import { isActionOf }                   from 'typesafe-actions'
+
+import * as Mailbox   from '../../src/mods/mod.js'
+
+import parentMachine, { duckula }    from './nested-mailbox-machine.js'
+
+test('actor smoke testing', async t => {
+  const TEST_ID = 'TestMachine'
+
+  const testMachine = Mailbox.wrap(parentMachine)
+
+  const eventList: AnyEventObject[] = []
+  const interpreter = interpret(testMachine)
+    .onEvent(e => {
+      console.info(TEST_ID, 'EVENT:', e.type, JSON.stringify(e))
+      eventList.push(e)
+    })
+    .start()
+
+  eventList.length = 0
+
+  const future = new Promise(resolve =>
+    interpreter.onEvent(e =>
+      isActionOf([
+        duckula.Event.COMPLETE,
+        ...Object.values(Mailbox.Event),
+      ], e) && resolve(e),
+    ),
+  )
+
+  console.info('############')
+  interpreter.send(duckula.Event.NEXT())
+  // await new Promise(resolve => setTimeout(resolve, 0))
+  await future
+
+  eventList.forEach(e => console.info(TEST_ID, 'final event list:', e.type, JSON.stringify(e)))
+  t.notOk(
+    Object.values(duckula.Type)
+      .some(
+        type => eventList
+          .map(e => e.type)
+          .includes(type)
+        ,
+      )
+    ,
+    'should not received any Mailbox.Type.* on the test machine',
+  )
+
+  t.same(eventList, [
+    duckula.Event.NEXT(),
+    duckula.Event.COMPLETE(),
+  ], 'should get NEXT then COMPLETE events')
+
+  await new Promise(setImmediate)
+  interpreter.stop()
+})

--- a/tests/machine-behaviors/nested-mailbox-machine.ts
+++ b/tests/machine-behaviors/nested-mailbox-machine.ts
@@ -1,0 +1,111 @@
+/* eslint-disable sort-keys */
+import { createMachine, actions }   from 'xstate'
+import { createAction }             from 'typesafe-actions'
+
+import * as Mailbox   from '../../src/mods/mod.js'
+
+enum State {
+  Idle = 'nested-mailbox/Idle',
+  Busy = 'nested-mailbox/Busy',
+}
+
+enum Type {
+  NEXT      = 'nested-mailbox/NEXT',
+  COMPLETE  = 'nested-mailbox/COMPLETE',
+}
+
+const Event = {
+  NEXT     : createAction(Type.NEXT)(),
+  COMPLETE : createAction(Type.COMPLETE)(),
+} as const
+
+interface Context {}
+
+export const duckula = Mailbox.duckularize({
+  id: 'Nested',
+  events: Event,
+  states: State,
+  initialContext: { i: 0 } as Context,
+})
+
+const CHILD_ID = 'Child'
+const childMachine = createMachine({
+  id: CHILD_ID,
+  initial: duckula.State.Idle,
+  states: {
+    [duckula.State.Idle]: {
+      entry: [
+        actions.log('states.Idle.entry', CHILD_ID),
+        Mailbox.actions.idle(CHILD_ID),
+      ],
+      on: {
+        [duckula.Type.NEXT]: {
+          actions: actions.log('states.Idle.on.NEXT', CHILD_ID),
+          target: duckula.State.Busy,
+        },
+      },
+    },
+
+    [duckula.State.Busy]: {
+      entry: [
+        actions.log('states.Busy.entry', CHILD_ID),
+        Mailbox.actions.reply(duckula.Event.COMPLETE(), { delay: 10 }),
+      ],
+      after: {
+        20: duckula.State.Idle,
+      },
+    },
+  },
+})
+
+const PARENT_MACHINE_ID = 'Parent'
+const parentMachine = createMachine<any, any>({
+  id: PARENT_MACHINE_ID,
+  initial: duckula.State.Idle,
+  states: {
+    [duckula.State.Idle]: {
+      entry: [
+        actions.log('states.Idle.entry', PARENT_MACHINE_ID),
+        Mailbox.actions.idle(PARENT_MACHINE_ID),
+      ],
+      on: {
+        [duckula.Type.NEXT]: {
+          actions: actions.log('states.Idle.on.NEXT', PARENT_MACHINE_ID),
+          target: duckula.State.Busy,
+        },
+      },
+    },
+
+    [duckula.State.Busy]: {
+      invoke: {
+        id: CHILD_ID,
+        src: Mailbox.wrap(childMachine),
+      },
+      entry: [
+        actions.log((_, e) => `states.Busy.entry ${e.type} ${JSON.stringify(e)}`, PARENT_MACHINE_ID),
+        actions.send((_, e) => e, { to: CHILD_ID }),
+      ],
+      on: {
+        '*': {
+          actions: actions.log((_, e) => `states.Busy.on ${JSON.stringify(e)}`, PARENT_MACHINE_ID),
+        },
+        [Mailbox.Type.ACTOR_REPLY]: {
+          actions: [
+            actions.log((_, e) => `states.Busy.on.ACTOR_REPLY ${JSON.stringify(e)}`, PARENT_MACHINE_ID),
+            actions.send<any, ReturnType<typeof Mailbox.Event.ACTOR_REPLY>>((_, e) => e.payload.message),
+          ],
+        },
+        [duckula.Type.COMPLETE]: {
+          actions: [
+            actions.log('states.Busy.on.COMPLETE', PARENT_MACHINE_ID),
+            Mailbox.actions.reply((_, e) => e),
+          ],
+          target: duckula.State.Idle,
+        },
+      },
+    },
+
+  },
+})
+
+export default parentMachine

--- a/tests/machine-behaviors/nested-mailbox-machine.ts
+++ b/tests/machine-behaviors/nested-mailbox-machine.ts
@@ -19,13 +19,11 @@ const Event = {
   COMPLETE : createAction(Type.COMPLETE)(),
 } as const
 
-interface Context {}
-
 export const duckula = Mailbox.duckularize({
   id: 'Nested',
   events: Event,
   states: State,
-  initialContext: { i: 0 } as Context,
+  initialContext: {},
 })
 
 const CHILD_ID = 'Child'
@@ -49,11 +47,9 @@ const childMachine = createMachine({
     [duckula.State.Busy]: {
       entry: [
         actions.log('states.Busy.entry', CHILD_ID),
-        Mailbox.actions.reply(duckula.Event.COMPLETE(), { delay: 10 }),
+        Mailbox.actions.reply(duckula.Event.COMPLETE()),
       ],
-      after: {
-        20: duckula.State.Idle,
-      },
+      always: duckula.State.Idle,
     },
   },
 })
@@ -88,6 +84,7 @@ const parentMachine = createMachine<any, any>({
       on: {
         '*': {
           actions: actions.log((_, e) => `states.Busy.on ${JSON.stringify(e)}`, PARENT_MACHINE_ID),
+          target: duckula.State.Idle,
         },
         [Mailbox.Type.ACTOR_REPLY]: {
           actions: [

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -14,6 +14,6 @@
     "scripts/**/*.ts",
     "src/**/*.ts",
     "tests/**/*.spec.ts",
-    "tests/machine-behaviors/*.ts",
+    "tests/machine-behaviors/**/.ts",
   ],
 }


### PR DESCRIPTION
The previous version of Mailbox was using a hard-coded ID for the wrapped machine, which will cause a conflict when we have nested Mailbox wrapped machines.

This PR generate distinct ID based on the wrapped machine ID.